### PR TITLE
Fix devcontainer and custom folder name issue

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
             ]
         }
     },
-    "postCreateCommand": "/workspaces/qmk_userspace/.devcontainer/setup.sh"
+    "postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/setup.sh ${containerWorkspaceFolder}"
 
     // Features to add to the dev container. More info: https://containers.dev/features.
     // "features": {},

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -9,13 +9,15 @@ rm get-pip.py
 
 python3 -m pip install --upgrade milc
 
-git config --global --add safe.directory /workspaces/qmk_userspace
+userspacePath="$1"
+
+git config --global --add safe.directory "$userspacePath"
 git submodule update --init --recursive
 
 [ -d /workspaces/qmk_firmware ] || git clone https://github.com/qmk/qmk_firmware.git /workspaces/qmk_firmware
 git config --global --add safe.directory /workspaces/qmk_firmware
 
 qmk config user.qmk_home=/workspaces/qmk_firmware
-qmk config user.overlay_dir=/workspaces/qmk_userspace
+qmk config user.overlay_dir="$userspacePath"
 
 qmk git-submodule


### PR DESCRIPTION
- folder name inside dev container is same as folder name on host so if it differs from qmk_userspace then setup.sh cannot be found and it sets incorrect user.overlay_dir
- solution is to use containerWorkspaceFolder var and pass it to setup.sh
- docs on devcontainer vars https://containers.dev/implementors/json_reference/

## Evidence
if folder name is different (like i named my fork `qmk_keymaps`) then setup.sh cannot be found
<img width="1112" alt="Screenshot 2024-04-18 at 09 37 39" src="https://github.com/qmk/qmk_userspace/assets/690135/b7ae0555-703f-4e79-ade9-0f87a330d46a">

tested my changes by commenting unchanged lines and rebuilding container
<img width="757" alt="Screenshot 2024-04-18 at 09 37 14" src="https://github.com/qmk/qmk_userspace/assets/690135/393eb6ab-1313-4f8d-a09a-22d7e5f8f8ad">
<img width="1317" alt="Screenshot 2024-04-18 at 09 37 01" src="https://github.com/qmk/qmk_userspace/assets/690135/39e65ed1-80ce-4953-9d82-1430c1803e4a">