### PR TITLE
Add clangd-related entries to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 *.hex
 *.bin
 *.uf2
+
+# clangd
+compile_commands.json
+.clangd/
+.cache/


### PR DESCRIPTION
This is needed to support VS Code with clangd for userspace keymaps (in this case `compile_commands.json` and `.cache/clangd` are located in the `qmk_userspace` working copy).
